### PR TITLE
Replace database variables by standards Mariadb variable names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM tiredofit/alpine:edge
 LABEL maintainer="Dave Conroy (dave at tiredofit dot ca)"
 
+RUN apt purge zabbix*
 ### Set Environment Variables
    ENV ENABLE_SMTP=FALSE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM tiredofit/alpine:edge
 LABEL maintainer="Dave Conroy (dave at tiredofit dot ca)"
 
-RUN apt purge zabbix*
+RUN apk del zabbix*
 ### Set Environment Variables
    ENV ENABLE_SMTP=FALSE
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ Along with the Environment Variables from the [Base image](https://hub.docker.co
 | Parameter | Description |
 |-----------|-------------|
 |  `DB_SERVER` | server name
-|  `DB_NAME` | database name
-|  `DB_USER` | username for the database - use root to backup all of them.
-|  `DB_PASS` | password for the database
+|  `MYSQL_DATABASE` | database name
+|  `MYSQL_USER` | username for the database - use root to backup all of them.
+|  `MYSQL_PASSWORD` | password for the database
 |  `DB_DUMP_FREQ` | How often to do a dump, in minutes. Defaults to 1440 minutes, or once per day.
 |  `DB_DUMP_BEGIN` | What time to do the first dump. Defaults to immediate. Must be in one of two formats
 | | Absolute HHMM, e.g. `2330` or `0415`

--- a/install/s6/services/10-mariadb-backup/run
+++ b/install/s6/services/10-mariadb-backup/run
@@ -18,14 +18,14 @@ DB_DUMP_BEGIN=${DB_DUMP_BEGIN:-+0}
 DB_DUMP_TARGET=${DB_DUMP_TARGET:-/backups}
 
 # login credentials
-DBUSER=${DB_USER}
-DBPASS=${DB_PASSWORD}
+DBUSER=${MYSQL_USER}
+DBPASS=${MYSQL_PASSWORD}
 
 # database server
 DBSERVER=${DB_SERVER}
 
 # database name
-DBNAME=${DB_NAME}
+DBNAME=${MYSQL_DATABASE}
 
 # temporary dump dir
 TMPDIR=/tmp/backups


### PR DESCRIPTION
Hello,
To easily integrate this image, I edited the db variables by the standards in the MariaDB image.
That allow to share env file between db container and backup container.
Cheers !